### PR TITLE
[BUGFIX] Bill + Legislator Sorting

### DIFF
--- a/api/endpoints/bills.py
+++ b/api/endpoints/bills.py
@@ -86,11 +86,13 @@ async def get_all_bill_details(
 
             column_filter = and_(*clauses)
 
-        order_by = (
-            [getattr(models.Bill, request_body.order_by), models.Bill.id]
-            if request_body.order_by
-            else [models.Bill.id]
-        )
+        order_by = []
+        if request_body.order_by:
+            sort_option = request_body.order_by.model_dump()
+            order_by = utils.create_sort_column_list(model=models.Bill, sort_option=sort_option)
+
+        order_by.append(models.Bill.id)
+
         search_filter = None
         if request_body.search_query:
             id_filter = utils.create_search_filter(

--- a/api/endpoints/legislators.py
+++ b/api/endpoints/legislators.py
@@ -63,11 +63,13 @@ async def get_legislators(
                 filter_options=filter_options,
             )
 
-        order_by = (
-            [getattr(models.Legislator, request_body.order_by), models.Legislator.id]
-            if request_body.order_by
-            else [models.Legislator.id]
-        )
+        order_by = []
+        if request_body.order_by:
+            sort_option = request_body.order_by.model_dump()
+            order_by = utils.create_sort_column_list(model=models.Legislator, sort_option=sort_option)
+
+        order_by.append(models.Legislator.id)
+
         search_filter = None
         if request_body.search_query:
             name_filter = utils.create_search_filter(

--- a/api/endpoints/legislators.py
+++ b/api/endpoints/legislators.py
@@ -66,7 +66,10 @@ async def get_legislators(
         order_by = []
         if request_body.order_by:
             sort_option = request_body.order_by.model_dump()
-            order_by = utils.create_sort_column_list(model=models.Legislator, sort_option=sort_option)
+            order_by = utils.create_sort_column_list(
+                model=models.Legislator,
+                sort_option=sort_option,
+            )
 
         order_by.append(models.Legislator.id)
 

--- a/api/schemas/interactions.py
+++ b/api/schemas/interactions.py
@@ -35,27 +35,33 @@ class FormErrorResponse(CamelCaseBaseModel):
 T = TypeVar("T")
 
 
-class BaseFilterOptions(CamelCaseBaseModel):
+class NoNullOptions(CamelCaseBaseModel):
+    @model_serializer()
+    def exclude_null_fields(self):
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
+class BaseFilterOptions(NoNullOptions):
     party_id: Optional[List[int]] = None
     role_id: Optional[List[int]] = None
     state_id: Optional[List[int]] = None
     status_id: Optional[List[int]] = None
-
-    @model_serializer()
-    def exclude_null_fields(self):
-        return {k: v for k, v in self.__dict__.items() if v is not None}
 
 
 class BasePaginationRequestBody(CamelCaseBaseModel):
     skip: int = 0
     limit: int = 100
     search_query: Optional[str] = None
-    order_by: Optional[str] = None
 
 
 class PaginatedResponse(CamelCaseBaseModel, Generic[T]):
     has_more: bool
     items: List[T]
+
+
+class SortingControllerEnum(str, Enum):
+    ASC = "ascending"
+    DESC = "descending"
 
 
 ####################
@@ -67,8 +73,15 @@ class BillFilterOptions(BaseFilterOptions):
     status_id: Optional[List[int]] = None
 
 
+class BillSortingOptions(NoNullOptions):
+    identifier: Optional[SortingControllerEnum] = None
+    title: Optional[SortingControllerEnum] = None
+    status_date: Optional[SortingControllerEnum] = None
+
+
 class BillPaginationRequestBody(BasePaginationRequestBody):
     filter_options: Optional[BillFilterOptions] = None
+    order_by: Optional[BillSortingOptions] = None
 
 
 ####################
@@ -94,8 +107,13 @@ class LegislatorFilterOptions(BaseFilterOptions):
     representing_state_id: Optional[List[int]] = None
 
 
+class LegislatorSortingOptions(NoNullOptions):
+    name: Optional[SortingControllerEnum] = None
+
+
 class LegislatorPaginationRequestBody(BasePaginationRequestBody):
     filter_options: Optional[LegislatorFilterOptions] = None
+    order_by: Optional[LegislatorSortingOptions] = None
 
 
 ####################

--- a/api/schemas/interactions.py
+++ b/api/schemas/interactions.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from datetime import datetime
 from pydantic import model_serializer, field_validator
-from typing import Optional, List, Generic, TypeVar, Union
+from typing import Dict, Optional, List, Generic, TypeVar, Union
 
 from common.core.schemas import CamelCaseBaseModel
 
@@ -95,6 +95,7 @@ class ExecutiveOrderFilterOptions(BaseFilterOptions):
 
 class ExecutiveOrderPaginationRequestBody(BasePaginationRequestBody):
     filter_options: Optional[BillFilterOptions] = None
+    order_by: Optional[Dict] = None
 
 
 ####################

--- a/api/tests/test_bills.py
+++ b/api/tests/test_bills.py
@@ -149,7 +149,7 @@ async def test_list_bill_details_sort(test_manager: TestManager):
     response = await test_manager.client.post(
         "/bills/details",
         headers=test_manager.headers,
-        json={"order_by": "title"},
+        json={"order_by": {"title": "ascending"}},
     )
     assert_status_code(response, 200)
     bills = response.json()

--- a/api/tests/test_legislators.py
+++ b/api/tests/test_legislators.py
@@ -80,7 +80,7 @@ async def test_list_legislators_sort(test_manager: TestManager):
     response = await test_manager.client.post(
         "/legislators/details",
         headers=test_manager.headers,
-        json={"order_by": "name"},
+        json={"order_by": {"name": "ascending"}},
     )
     assert_status_code(response, 200)
     legislators = response.json()

--- a/common/database/referendum/utils.py
+++ b/common/database/referendum/utils.py
@@ -1,9 +1,10 @@
-from typing import Dict, List, Type
 from enum import Enum
+from typing import Dict, List, Type
 
 from sqlalchemy import Column, and_, func
 from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
 
+from api.schemas.interactions import SortingControllerEnum
 from common.database.referendum.crud import ModelType
 
 
@@ -34,3 +35,17 @@ def create_search_filter(
     return func.to_tsvector(search_config.value, model_fields).op("@@")(
         query_func(search_config.value, search_text)
     )
+
+
+def create_sort_column_list(
+    model: Type[ModelType],
+    sort_option: Dict[str, SortingControllerEnum],
+) -> List[Column]:
+    return [
+        (
+            getattr(model, field).desc()
+            if control == SortingControllerEnum.DESC
+            else getattr(model, field)
+        )
+        for field, control in sort_option.items()
+    ]


### PR DESCRIPTION
- Failing to sort `status_date` because we were relying on pydantic to handle converting camel base -> snake case
- Since we aren't passing the fields as model attributes the conversion wasn't happening
- Change the shape of the `order_by` attribute in the request so we get the built in snake case conversions
- Add utility function to unpack the new sorting structure